### PR TITLE
QA-639: Fix sanity check for latest yocto golang version

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,4 +13,5 @@ include:
       - '.gitlab-ci-check-license.yml'
 
 # Keep golang version aligned with latest yocto release
-image: golang:1.17-alpine3.16
+test:unit:
+  image: golang:1.17


### PR DESCRIPTION
With the previous code, the `image` key defined inside the templated jobs was taking precedence over the "default" `image` key defined here.