### PR TITLE
cherrypick 1.0.x: Add an explicit compatibility test + Bump license year

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,6 +12,9 @@ include:
       - '.gitlab-ci-check-commits.yml'
       - '.gitlab-ci-check-license.yml'
 
-# Keep golang version aligned with latest yocto release
-test:unit:
-  image: golang:1.17
+# Test that we can build with the golang version of the oldest supported yocto LTS release
+test:backwards-compatibility:
+  image: golang:1.17.13-bullseye
+  needs: []
+  script:
+    - go build

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2024 Northern.tech AS
+Copyright 2025 Northern.tech AS
 
 All content in this project is licensed under the Apache License v2, unless
 indicated otherwise.

--- a/LIC_FILES_CHKSUM.sha256
+++ b/LIC_FILES_CHKSUM.sha256
@@ -1,5 +1,5 @@
 # Apache 2.0 licenses.
-d0f406b04e7901e6b4076bdf5fd20f9d7f04fc41681069fd8954413ac6295688  LICENSE
+38791d93beae962b266e11ac888ea2af4f07578b272c2f9dcb05f54f32960a76  LICENSE
 8f5d89b47d7a05a199b77b7e0f362dad391d451ebda4ef48ba11c50c071564c7  vendor/github.com/mendersoftware/progressbar/LICENSE
 
 # BSD-3


### PR DESCRIPTION
Outdated test:unit job, https://gitlab.com/Northern.tech/Mender/mender-snapshot/-/jobs/8895103402