### PR TITLE
ci: add qa-common retry and runner defaults

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,6 +4,10 @@ stages:
   - publish
 
 include:
+  - project: Northern.tech/Mender/mendertesting
+    file:
+      - qa-common/runner.yml
+      - qa-common/retry.yml
   - project: 'Northern.tech/Mender/mendertesting'
     file:
       - '.gitlab-ci-github-status-updates.yml'
@@ -11,6 +15,10 @@ include:
       - '.gitlab-ci-check-golang-unittests.yml'
       - '.gitlab-ci-check-commits.yml'
       - '.gitlab-ci-check-license.yml'
+
+default:
+  tags: !reference [.qa-common-default-runner, tags]
+  retry: !reference [.qa-common-default-retry, retry]
 
 # Test that we can build with the golang version of the oldest supported yocto LTS release
 test:backwards-compatibility:


### PR DESCRIPTION
Include qa-common/runner.yml and qa-common/retry.yml from mendertesting to apply a consistent .qa-common-default-runner tag and .qa-common-default-retry policy to all jobs pipeline-wide.

Add network probes (apt/go/git-clone) to jobs that perform network operations, so transient failures trigger a retry instead of a hard fail.

Ticket: QA-1490