### PR TITLE
[Cherry 1.0.x] chore: Use a gitlab component for checking yocto GO build compatibility

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -11,10 +11,4 @@ include:
       - '.gitlab-ci-check-golang-unittests.yml'
       - '.gitlab-ci-check-commits.yml'
       - '.gitlab-ci-check-license.yml'
-
-# Test that we can build with the golang version of the oldest supported yocto LTS release
-test:backwards-compatibility:
-  image: golang:1.17.13-bullseye
-  needs: []
-  script:
-    - go build
+  - component: gitlab.com/Northern.tech/Mender/mendertesting/backwards-compatible-yocto@master

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2025 Northern.tech AS
+Copyright 2026 Northern.tech AS
 
 All content in this project is licensed under the Apache License v2, unless
 indicated otherwise.

--- a/LIC_FILES_CHKSUM.sha256
+++ b/LIC_FILES_CHKSUM.sha256
@@ -1,5 +1,5 @@
 # Apache 2.0 licenses.
-38791d93beae962b266e11ac888ea2af4f07578b272c2f9dcb05f54f32960a76  LICENSE
+d7e8fd4ad05371007d60285c309ba7a7ce3e61029b843f949fbb9ec79dc9eb47  LICENSE
 8f5d89b47d7a05a199b77b7e0f362dad391d451ebda4ef48ba11c50c071564c7  vendor/github.com/mendersoftware/progressbar/LICENSE
 
 # BSD-3


### PR DESCRIPTION
Ticket: MEN-9689


(cherry picked from commit caac952f7e936b1f18e992660a360daacaa93aa2)